### PR TITLE
Don't fail if major performance caveat

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -12,7 +12,9 @@ function onDocumentReady(callback: () => void): void {
     document.addEventListener('DOMContentLoaded', callback);
   }
 }
+
 PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST;
+PIXI.settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = false;
 
 function startGame(
   previousScores?: { name: PIXI.Text; score: PIXI.Text }[],


### PR DESCRIPTION
Pixi 5 funkar inte alls för mig o staffan i firefox. Kort o gott så vill pixi ha features från WebGL som firefox inte tycker att den har med hårdvaran den kör på, eller så är hårdvaruaccelerering avstängt.

En utav två lösningar till detta är att sätta en flagga till false. Jag vet inte hur mycket sämre performance det blir för alla med denna. Det verkade sämre för mig i firefox iaf jämfört med vad jag använder vanligen. 

Den andra lösningen är att använda `pixi5.js-legacy`, men jag vet inte hur det kommer att se ut för oss i koden.

https://github.com/pixijs/pixi.js/issues/5694
https://github.com/pixijs/pixi.js/issues/5774