### PR TITLE
Client Side Prediction

### DIFF
--- a/src/client/clientSimulation.ts
+++ b/src/client/clientSimulation.ts
@@ -1,14 +1,14 @@
 import GameMap from '../common/gameMap';
 import { Input, Id } from '../common/misc';
 import Simulation, { createBody } from '../common/simulation';
-import seedrandom from 'seedrandom';
 
 import State from '../common/state';
 
 export interface SimState {
   state: State;
   stepCounter: number;
-  rngState: seedrandom.State;
+  // NOTE: intentionally ignored
+  rngState: undefined; //seedrandom.State;
 }
 
 export default class ClientSimulation extends Simulation {
@@ -38,7 +38,8 @@ export default class ClientSimulation extends Simulation {
 
   public reset(simState: SimState): void {
     this._stepCounter = simState.stepCounter;
-    this._random = seedrandom('', { state: simState.rngState });
+    // NOTE: intentionally ignored
+    // this._random = seedrandom('', { state: simState.rngState });
     const state = simState.state;
 
     const newPlayerIds = new Array<string>();
@@ -86,7 +87,8 @@ export default class ClientSimulation extends Simulation {
   public snapshot(): SimState {
     return {
       state: this.state.clone(),
-      rngState: this._random.state(),
+      // NOTE: intentionally ignored
+      rngState: undefined, //this._random.state(),
       stepCounter: this._stepCounter,
     };
   }

--- a/src/client/clientSimulation.ts
+++ b/src/client/clientSimulation.ts
@@ -21,6 +21,10 @@ export default class ClientSimulation extends Simulation {
     super(map, updateStep, numPlayers, seed, { state: true });
   }
 
+  protected updateWave(_killed: number): void {
+    return;
+  }
+
   public update(me: Id, input: Input): void {
     this.commonUpdate();
 

--- a/src/client/clientSimulation.ts
+++ b/src/client/clientSimulation.ts
@@ -7,6 +7,7 @@ import State from '../common/state';
 
 export interface SimState {
   state: State;
+  stepCounter: number;
   rngState: seedrandom.State;
 }
 
@@ -36,6 +37,7 @@ export default class ClientSimulation extends Simulation {
   }
 
   public reset(simState: SimState): void {
+    this._stepCounter = simState.stepCounter;
     this._random = seedrandom('', { state: simState.rngState });
     const state = simState.state;
 
@@ -85,6 +87,7 @@ export default class ClientSimulation extends Simulation {
     return {
       state: this.state.clone(),
       rngState: this._random.state(),
+      stepCounter: this._stepCounter,
     };
   }
 }

--- a/src/client/clientSimulation.ts
+++ b/src/client/clientSimulation.ts
@@ -24,10 +24,9 @@ export default class ClientSimulation extends Simulation {
     this.commonUpdate();
 
     const my_body = this.bodies.get(me);
-    if (my_body === undefined) {
-      throw new Error("I don't exists?");
+    if (my_body !== undefined) {
+      this.handlePlayerInput(my_body, this.state.players[me], input);
     }
-    this.handlePlayerInput(my_body, this.state.players[me], input);
     // TODO: move the other players in the same direction as they were walking
     // in before
 

--- a/src/client/clientSimulation.ts
+++ b/src/client/clientSimulation.ts
@@ -1,6 +1,7 @@
 import GameMap from '../common/gameMap';
 import { Input, Id } from '../common/misc';
 import Simulation, { createBody } from '../common/simulation';
+import { Vec2 } from 'planck-js';
 
 import State from '../common/state';
 
@@ -25,6 +26,14 @@ export default class ClientSimulation extends Simulation {
     return;
   }
 
+  private predictOtherPlayers(me: Id): void {
+    for (const [id, body] of this._bodies) {
+      if (!(id in this.state.players) || id === me) return;
+      // don't predict other players
+      body.setLinearVelocity(Vec2.zero());
+    }
+  }
+
   public update(me: Id, input: Input): void {
     this.commonUpdate();
 
@@ -32,8 +41,8 @@ export default class ClientSimulation extends Simulation {
     if (my_body !== undefined) {
       this.handlePlayerInput(my_body, this.state.players[me], input);
     }
-    // TODO: move the other players in the same direction as they were walking
-    // in before
+
+    this.predictOtherPlayers(me);
 
     this.world.step(this.updateStep);
 

--- a/src/client/csp.ts
+++ b/src/client/csp.ts
@@ -54,7 +54,8 @@ export class Smarty implements Predictor {
 
   public get state(): State {
     const last = this.states.last_elem();
-    if (last === undefined) throw new Error("this can't be empty");
+    if (last === undefined)
+      throw new Error('there should always be at least one state');
     return last.state;
   }
 

--- a/src/client/csp.ts
+++ b/src/client/csp.ts
@@ -1,0 +1,44 @@
+import Deque from '../common/deque';
+import { Input } from '../common/misc';
+import State from '../common/state';
+import constants from '../common/constants';
+import ClientSimulation from './clientSimulation';
+import GameMap from '../common/gameMap';
+
+export default class CSP {
+  // predicted states where the first one always is a `true` state from the
+  // server.
+  private states: Deque<State>;
+  // inputs that caused all states in `states`.
+  // private statesInputs: Deque<Input>
+  private sim: ClientSimulation;
+
+  constructor(map: GameMap, numPlayers: number, seed: string) {
+    this.states = new Deque();
+    this.sim = new ClientSimulation(
+      map,
+      1 / constants.CLIENT.UPS,
+      numPlayers,
+      seed,
+    );
+    this.states.push_back(this.sim.state);
+  }
+
+  public get state(): State {
+    const last = this.states.last_elem();
+    if (last === undefined) throw new Error("this can't be empty");
+    return last;
+  }
+
+  public get stateNum(): number {
+    return this.states.last;
+  }
+
+  public predict(input: Input): void {
+    1 + 1;
+  }
+
+  public setTruth(state: State, stateNum: number): void {
+    this.states.reset(state, stateNum);
+  }
+}

--- a/src/client/csp.ts
+++ b/src/client/csp.ts
@@ -1,11 +1,36 @@
 import Deque from '../common/deque';
-import { Input } from '../common/misc';
+import { Input, Id } from '../common/misc';
 import State from '../common/state';
 import constants from '../common/constants';
-import ClientSimulation from './clientSimulation';
+import ClientSimulation, { SimState } from './clientSimulation';
 import GameMap from '../common/gameMap';
 
-export default class CSP {
+export interface Predictor {
+  predict(input: Input): void;
+  setTruth(state: State, stateNum: number): void;
+  stateNum: number;
+  state: State;
+}
+
+export class Dummy implements Predictor {
+  public state;
+  public stateNum;
+
+  constructor() {
+    this.stateNum = 0;
+    this.state = new State();
+  }
+  public predict(input: Input): void {
+    input;
+  }
+
+  public setTruth(state: State, stateNum: number): void {
+    this.state = state;
+    this.stateNum = stateNum;
+  }
+}
+
+export class Smarty implements Predictor {
   // predicted states where the first one always is a `true` state from the
   // server.
   private states: Deque<State>;

--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -140,7 +140,7 @@ export default class ClientGame extends GameLoop {
       this.inputHistory.discard_front_until(message.inputAck[this.my_id]);
     }
 
-    this.predictor.setTruth(message.state, this.inputHistory);
+    this.predictor.setTruth(message.state, message.stateNum, this.inputHistory);
   }
 
   update_player_sprites(newState: State, stateNum: number): void {

--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -65,7 +65,7 @@ export default class ClientGame extends GameLoop {
     this.my_id = args.my_id;
     this.map = args.map;
 
-    if (constants.CLIENT.CSP) {
+    if (constants.CLIENT.ENABLE_CSP) {
       this.predictor = new CSP.Smarty(
         this.map,
         args.numPlayers,

--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -5,7 +5,7 @@ import ByteBuffer from 'bytebuffer';
 import Deque from '../common/deque';
 import { Input } from '../common/misc';
 import { Player } from '../common/entity';
-import CSP from './csp';
+import * as CSP from './csp';
 
 import { deserializeSTC, serialize } from '../common/msg';
 import State from '../common/state';
@@ -32,7 +32,7 @@ export default class ClientGame extends GameLoop {
   private stage;
   private map;
 
-  private predictor;
+  private predictor: CSP.Predictor;
 
   // inputs not confirmed by server
   private inputHistory: Deque<Input>;
@@ -64,7 +64,12 @@ export default class ClientGame extends GameLoop {
     this.lastSentInput = -1;
     this.my_id = args.my_id;
     this.map = args.map;
-    this.predictor = new CSP(this.map, args.numPlayers, args.seed);
+
+    if (constants.CLIENT.CSP) {
+      this.predictor = new CSP.Smarty(this.map, args.numPlayers, args.seed);
+    } else {
+      this.predictor = new CSP.Dummy();
+    }
   }
 
   public start(): Promise<void> {
@@ -473,7 +478,7 @@ export default class ClientGame extends GameLoop {
   }
 
   update_scoreboard(state: State): void {
-    this.score.text = 'Score: ' + state.players[this.my_id].score;
+    this.score.text = 'Score: ' + state.players[this.my_id]?.score;
     this.waveNumber.text = 'Wave: ' + state.wave;
   }
 }

--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -66,7 +66,12 @@ export default class ClientGame extends GameLoop {
     this.map = args.map;
 
     if (constants.CLIENT.CSP) {
-      this.predictor = new CSP.Smarty(this.map, args.numPlayers, args.seed);
+      this.predictor = new CSP.Smarty(
+        this.map,
+        args.numPlayers,
+        args.seed,
+        args.my_id,
+      );
     } else {
       this.predictor = new CSP.Dummy();
     }
@@ -108,7 +113,7 @@ export default class ClientGame extends GameLoop {
 
     this.inputHistory.push_back(inp);
 
-    this.predictor.predict(inp);
+    this.predictor.predict(this.inputHistory);
     const newState = this.predictor.state;
     const stateNum = this.predictor.stateNum;
 
@@ -135,7 +140,7 @@ export default class ClientGame extends GameLoop {
       this.inputHistory.discard_front_until(message.inputAck[this.my_id]);
     }
 
-    this.predictor.setTruth(message.state, message.stateNum);
+    this.predictor.setTruth(message.state, this.inputHistory);
   }
 
   update_player_sprites(newState: State, stateNum: number): void {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -94,6 +94,7 @@ function startGame(
         map,
         my_id: data['id'],
         seed: data['random_seed'],
+        numPlayers: Object.values(playerNames).length,
       });
 
       game.start().then(() => {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -38,6 +38,34 @@ export const CLIENT = {
   MAX_INPUTS: 20,
 };
 
+/** Map and tile constants. */
+export const MAP = {
+  /**
+   * How big a tile should be drawn as. This determines the final scale of the
+   * game and is the only constant expressed in pixels.
+   */
+  TILE_TARGET_SIZE_PIXELS: 48,
+
+  /**
+   * How big a tile or square is logically. Everything else will be dependent on
+   * this. The unit is in meters.
+   */
+  TILE_LOGICAL_SIZE: 1,
+
+  /** Turn a logical unit (meters) to its corresponding pixel size. */
+  LOGICAL_TO_PIXELS: (logical: number): number =>
+    (logical * MAP.TILE_TARGET_SIZE_PIXELS) / MAP.TILE_LOGICAL_SIZE,
+
+  /** Name of the tile layer that holds the tile data of a map. */
+  TILE_LAYER_LAYER_NAME: 'Map',
+
+  /** Name of the object group layer that holds spawn positions of players. */
+  PLAYER_SPAWN_LAYER_NAME: 'Player spawn',
+
+  /** Name of the object group layer that holds spawn positions of enemies. */
+  ENEMY_SPAWN_LAYER_NAME: 'Enemy spawn',
+};
+
 /** Game constants. */
 export const GAME = {
   /** Maximum and initial health of a player. */
@@ -72,34 +100,12 @@ export const GAME = {
 
   /** Delay (in seconds) between waves. */
   WAVE_COOLDOWN: 3,
-};
-
-/** Map and tile constants. */
-export const MAP = {
-  /**
-   * How big a tile should be drawn as. This determines the final scale of the
-   * game and is the only constant expressed in pixels.
-   */
-  TILE_TARGET_SIZE_PIXELS: 48,
 
   /**
-   * How big a tile or square is logically. Everything else will be dependent on
-   * this. The unit is in meters.
+   * How many meters is considered "too different" on entity positions when
+   * comparing two states.
    */
-  TILE_LOGICAL_SIZE: 1,
-
-  /** Turn a logical unit (meters) to its corresponding pixel size. */
-  LOGICAL_TO_PIXELS: (logical: number): number =>
-    (logical * MAP.TILE_TARGET_SIZE_PIXELS) / MAP.TILE_LOGICAL_SIZE,
-
-  /** Name of the tile layer that holds the tile data of a map. */
-  TILE_LAYER_LAYER_NAME: 'Map',
-
-  /** Name of the object group layer that holds spawn positions of players. */
-  PLAYER_SPAWN_LAYER_NAME: 'Player spawn',
-
-  /** Name of the object group layer that holds spawn positions of enemies. */
-  ENEMY_SPAWN_LAYER_NAME: 'Enemy spawn',
+  TOLERANCE: MAP.TILE_LOGICAL_SIZE / (MAP.TILE_TARGET_SIZE_PIXELS * 5),
 };
 
 /** UI constants. */
@@ -125,3 +131,5 @@ export const UI = {
   /** How many pixels an hp bar is. */
   HP_BAR_FLOAT: 30,
 };
+
+export default { UI, MAP, CLIENT, SERVER, GAME };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -27,6 +27,9 @@ export const SERVER = {
    * many updates without getting popped.
    */
   INPUT_QUEUE_MAX_AGE: 3,
+
+  /** Amount of one-way networking delay in milliseconds */
+  DELAY: 0,
 };
 
 /** Client constants. */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,9 +1,12 @@
 /** Server constants. */
 export const SERVER = {
-  /** Number of server updates per second. */
+  /** Number of server updates per second. How fast the game runs. */
   UPS: 60,
 
-  /** Number of server frames per second. */
+  /**
+   * How many times the server checks whether is should update. Should be the
+   * same as it's UPS.
+   */
   FPS: 60,
 
   /** Server port. */
@@ -28,10 +31,16 @@ export const SERVER = {
 
 /** Client constants. */
 export const CLIENT = {
-  /** Number of client updates per second. */
+  /**
+   * How many times per second the client should send inputs and update its
+   * predictor. This should be the same as the server's UPS.
+   */
   UPS: 60,
 
-  /** Number of client frames per second. */
+  /**
+   * Number of client frames per second. This doesn't do anything at the moment
+   * since the actual FPS is determined by the browser
+   */
   FPS: 60,
 
   /** Maximum number of inputs to send to the server at a time. */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -51,6 +51,9 @@ export const CLIENT = {
 
   /** Maximum number of inputs to send to the server at a time. */
   MAX_INPUTS: 20,
+
+  /** Whether to use Client Side Prediction or not. */
+  CSP: false,
 };
 
 /** Map and tile constants. */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -30,6 +30,9 @@ export const SERVER = {
 
   /** Amount of one-way networking delay in milliseconds */
   DELAY: 0,
+
+  /** The chance that an incoming or outgoing package will be dropped. [0, 1] */
+  DROP: 0,
 };
 
 /** Client constants. */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -50,7 +50,7 @@ export const CLIENT = {
   FPS: 60,
 
   /** Maximum number of inputs to send to the server at a time. */
-  MAX_INPUTS: 20,
+  MAX_INPUTS: 100,
 
   /** Whether to use Client Side Prediction or not. */
   CSP: false,
@@ -123,7 +123,7 @@ export const GAME = {
    * How many meters is considered "too different" on entity positions when
    * comparing two states.
    */
-  TOLERANCE: MAP.TILE_LOGICAL_SIZE / (MAP.TILE_TARGET_SIZE_PIXELS * 5),
+  TOLERANCE: MAP.TILE_LOGICAL_SIZE / MAP.TILE_TARGET_SIZE_PIXELS,
 };
 
 /** UI constants. */

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -29,10 +29,10 @@ export const SERVER = {
   INPUT_QUEUE_MAX_AGE: 3,
 
   /** Amount of one-way networking delay in milliseconds */
-  DELAY: 0,
+  NETWORK_DELAY: 0,
 
   /** The chance that an incoming or outgoing package will be dropped. [0, 1] */
-  DROP: 0,
+  NETWORK_DROP_CHANCE: 0,
 };
 
 /** Client constants. */
@@ -53,7 +53,7 @@ export const CLIENT = {
   MAX_INPUTS: 100,
 
   /** Whether to use Client Side Prediction or not. */
-  CSP: false,
+  ENABLE_CSP: false,
 };
 
 /** Map and tile constants. */

--- a/src/common/deque.ts
+++ b/src/common/deque.ts
@@ -133,6 +133,31 @@ export default class Deque<T> {
   }
 
   /**
+   * Shifts all values forward until `this.first` is equal to `newFirst`. It can
+   * only shift forwards.
+   * @param newFirst the new value of first
+   */
+  public shift_forward(newFirst: number): void {
+    const len = this.length;
+    if ((len === 0 && newFirst <= this._first) || newFirst < this._first)
+      throw new Error('shift_forward cannot shift backwards');
+
+    this._first = newFirst;
+    if (this._last === null) {
+      this._first -= 1;
+      return;
+    }
+
+    let oldLast = this._last;
+    this._last = this._first + len - 1;
+    for (let i = this._last; i >= this._first; i--) {
+      this.data[i] = this.data[oldLast];
+      delete this.data[oldLast];
+      oldLast -= 1;
+    }
+  }
+
+  /**
    * @returns The values of this deque in an [[Array]].
    */
   public toArray(): T[] {

--- a/src/common/entity.ts
+++ b/src/common/entity.ts
@@ -7,7 +7,6 @@ import Weapon from './weapon';
  */
 export abstract class Entity {
   public readonly id: Id;
-  public readonly maxHealth: number;
 
   public position: Vec2;
   public velocity: Vec2;
@@ -15,6 +14,7 @@ export abstract class Entity {
   public walking: boolean;
 
   private _health: number;
+  public maxHealth: number;
 
   public constructor(id: Id, health: number, position: Vec2) {
     this.id = id;
@@ -47,6 +47,7 @@ export abstract class Entity {
     e.velocity = this.velocity.clone();
     e.direction = this.direction.clone();
     e.walking = this.walking;
+    e.maxHealth = this.maxHealth;
 
     return e;
   }

--- a/src/common/entity.ts
+++ b/src/common/entity.ts
@@ -165,7 +165,11 @@ export class Player extends Entity {
    */
   public clone(): Player {
     return super.clone(() => {
-      return new Player(this.id, this.health, this.position.clone());
+      const p = new Player(this.id, this.health, this.position.clone());
+      p._score = this.score;
+      p.target = this.target.clone();
+      p.weapons = this.weapons.map(w => w.clone());
+      return p;
     }) as Player;
   }
 

--- a/src/common/entity.ts
+++ b/src/common/entity.ts
@@ -1,6 +1,7 @@
-import { Id, PopArray } from './misc';
+import { Id, PopArray, floatEq, arrayEq } from './misc';
 import { Body, Vec2 } from 'planck-js';
 import Weapon from './weapon';
+
 /**
  * A generic entity. It has health, a position, and a velocity.
  */
@@ -23,6 +24,21 @@ export abstract class Entity {
     this.position = position;
     this.velocity = Vec2.zero();
     this.direction = new Vec2(0, -1);
+  }
+
+  public isSimilarTo(other: Entity, tolerance: number): boolean {
+    return (
+      this.id === other.id &&
+      this.maxHealth === other.maxHealth &&
+      this.walking === other.walking &&
+      this._health === other._health &&
+      floatEq(this.position.x, other.position.x, tolerance) &&
+      floatEq(this.position.y, other.position.y, tolerance) &&
+      floatEq(this.velocity.x, other.velocity.x, tolerance) &&
+      floatEq(this.velocity.y, other.velocity.y, tolerance) &&
+      floatEq(this.direction.x, other.direction.x, tolerance) &&
+      floatEq(this.direction.y, other.direction.y, tolerance)
+    );
   }
 
   public clone(construct: () => Entity): Entity {
@@ -132,6 +148,18 @@ export class Player extends Entity {
     this._score += points;
   }
 
+  public isSimilarTo(other: Entity, tolerance: number): boolean {
+    if (!(other instanceof Player)) return false;
+    const o = other as Player;
+    return (
+      super.isSimilarTo(other, tolerance) &&
+      this._score === o._score &&
+      floatEq(this.target.x, o.target.x, tolerance) &&
+      floatEq(this.target.y, o.target.y, tolerance) &&
+      arrayEq(this.weapons, o.weapons, (w1, w2) => w1.equals(w2))
+    );
+  }
+
   /**
    * Returns a deep copy of a `Player`.
    */
@@ -190,6 +218,19 @@ export class Enemy extends Entity {
     this.knockbackVelocity = Vec2.zero();
     this.knockbackTime = 0;
     this.score = score;
+  }
+
+  public isSimilarTo(other: Entity, tolerance: number): boolean {
+    if (!(other instanceof Enemy)) return false;
+    const o = other as Enemy;
+    return (
+      super.isSimilarTo(other, tolerance) &&
+      this.damage === o.damage &&
+      this.knockbackTime === o.knockbackTime &&
+      this.score === o.score &&
+      floatEq(this.knockbackVelocity.x, o.knockbackVelocity.x, tolerance) &&
+      floatEq(this.knockbackVelocity.y, o.knockbackVelocity.y, tolerance)
+    );
   }
 
   /**

--- a/src/common/misc.ts
+++ b/src/common/misc.ts
@@ -116,3 +116,19 @@ export function randomString(length: number): string {
   }
   return result;
 }
+
+export function floatEq(f1: number, f2: number, tolerance: number): boolean {
+  return Math.abs(f1 - f2) <= tolerance;
+}
+
+export function arrayEq<A, B>(
+  arr1: A[],
+  arr2: B[],
+  comparator: (A, B) => boolean,
+): boolean {
+  if (arr1.length !== arr2.length) return false;
+  for (let i = 0; i < arr1.length; i++) {
+    if (!comparator(arr1[i], arr2[i])) return false;
+  }
+  return true;
+}

--- a/src/common/simulation.ts
+++ b/src/common/simulation.ts
@@ -17,7 +17,7 @@ export default abstract class Simulation {
   protected _stepCounter: number;
   protected _wave: Wave;
   protected _numPlayers: number;
-  protected _random: seedrandom.prng;
+  protected _random: undefined; //seedrandom.prng;
 
   public timeOfDamageTaken: Map<Id, number>;
   public enemyContacts: Map<Id, Id[]>;
@@ -54,7 +54,8 @@ export default abstract class Simulation {
     seed: string,
     seedrandomOptions?: seedrandom.seedRandomOptions,
   ) {
-    this._random = seedrandom(seed, seedrandomOptions);
+    // NOTE: intentionally ignored
+    this._random = undefined; //seedrandom(seed, seedrandomOptions);
     this.updateStep = updateStep;
     this._world = this.createWorld(map);
     this._bodies = new Map<Id, Body>();

--- a/src/common/simulation.ts
+++ b/src/common/simulation.ts
@@ -15,7 +15,6 @@ export default abstract class Simulation {
   protected _bodies: Map<Id, Body>;
   protected _state: State;
   protected _stepCounter: number;
-  protected _enemyIdCounter: number;
   protected _wave: Wave;
   protected _numPlayers: number;
   protected _random: seedrandom.prng;
@@ -61,7 +60,7 @@ export default abstract class Simulation {
     this._bodies = new Map<Id, Body>();
     this._state = new State();
     this._stepCounter = 0;
-    this._enemyIdCounter = numPlayers;
+    this.state.enemyIdCounter = numPlayers;
     this._gameMap = map;
     this._wave = new Wave(
       1,
@@ -145,29 +144,29 @@ export default abstract class Simulation {
   // Should probably have a type of enemy as well for later
 
   public addEnemy(health: number): void {
-    if (this._enemyIdCounter in this.state.players)
+    if (this.state.enemyIdCounter in this.state.players)
       throw new Error(
-        `ID ${this._enemyIdCounter} is already taken (by a player).`,
+        `ID ${this.state.enemyIdCounter} is already taken (by a player).`,
       );
 
-    if (this._enemyIdCounter in this.state.enemies)
+    if (this.state.enemyIdCounter in this.state.enemies)
       throw new Error(
-        `ID ${this._enemyIdCounter} is already taken (by an enemy).`,
+        `ID ${this.state.enemyIdCounter} is already taken (by an enemy).`,
       );
 
     const position = this._gameMap.randomEnemySpawn(this._random);
     const enemy_damage = 1; //Snälla Dark Vader, blunda när du ser detta. Det är tillfälligt och bör ändras om vi har olika typer av fiender...
     const enemy_score = 10; // ――″――
     const enemy = new Enemy(
-      this._enemyIdCounter,
+      this.state.enemyIdCounter,
       health,
       position,
       enemy_damage,
       enemy_score,
     );
-    this.state.enemies[this._enemyIdCounter] = enemy;
-    this.bodies.set(this._enemyIdCounter, createBody(this.world, enemy));
-    this._enemyIdCounter += 1;
+    this.state.enemies[this.state.enemyIdCounter] = enemy;
+    this.bodies.set(this.state.enemyIdCounter, createBody(this.world, enemy));
+    this.state.enemyIdCounter += 1;
   }
 
   private despawnEntities(): number {

--- a/src/common/simulation.ts
+++ b/src/common/simulation.ts
@@ -71,6 +71,10 @@ export default abstract class Simulation {
     this._numPlayers = numPlayers;
     this.timeOfDamageTaken = new Map<Id, Id>();
     this.enemyContacts = new Map<Id, Id[]>();
+
+    for (let i = 0; i < numPlayers; i++) {
+      this.addPlayer(i);
+    }
   }
 
   public commonUpdate(): void {

--- a/src/common/simulation.ts
+++ b/src/common/simulation.ts
@@ -77,12 +77,7 @@ export default abstract class Simulation {
     }
   }
 
-  public commonUpdate(): void {
-    this._stepCounter += 1;
-
-    this.playerTakeDamage();
-
-    const killed = this.despawnEntities();
+  protected updateWave(killed: number): void {
     this._wave.kill(killed);
 
     if (this._wave.finished) {
@@ -114,6 +109,15 @@ export default abstract class Simulation {
         this._wave.spawnSingle();
       }
     }
+  }
+
+  public commonUpdate(): void {
+    this._stepCounter += 1;
+
+    this.playerTakeDamage();
+
+    const killed = this.despawnEntities();
+    this.updateWave(killed);
 
     this.moveEnemies();
   }

--- a/src/common/state.ts
+++ b/src/common/state.ts
@@ -1,5 +1,5 @@
 import { Player, Enemy } from './entity';
-import { NumMap, PopArray } from './misc';
+import { NumMap, PopArray, arrayEq } from './misc';
 
 export default class State {
   public players: NumMap<Player> = {};
@@ -61,5 +61,26 @@ export default class State {
     state.enemies = enemies;
     state.wave = wave;
     return state;
+  }
+
+  public isSimilarTo(other: State, tolerance: number): boolean {
+    // NOTE: this.wave is only used to display a number on the screen. It is not
+    // worth it to say that these two states are different solely because of
+    // wave.
+    const myStuff = [
+      ...Object.values(this.players),
+      ...Object.values(this.enemies),
+    ];
+    const otherStuff = [
+      ...Object.values(other.players),
+      ...Object.values(other.enemies),
+    ];
+
+    if (myStuff.length !== otherStuff.length) return false;
+
+    myStuff.sort((a, b) => a.id - b.id);
+    otherStuff.sort((a, b) => a.id - b.id);
+
+    return arrayEq(myStuff, otherStuff, (m, o) => m.isSimilarTo(o, tolerance));
   }
 }

--- a/src/common/state.ts
+++ b/src/common/state.ts
@@ -88,4 +88,12 @@ export default class State {
 
     return arrayEq(myStuff, otherStuff, (m, o) => m.isSimilarTo(o, tolerance));
   }
+
+  public translateTimestamps(translate: number): void {
+    for (const p of Object.values(this.players)) {
+      for (const w of p.weapons) {
+        w.timeOfLastShot += translate;
+      }
+    }
+  }
 }

--- a/src/common/state.ts
+++ b/src/common/state.ts
@@ -5,6 +5,7 @@ export default class State {
   public players: NumMap<Player> = {};
   public enemies: NumMap<Enemy> = {};
   public wave = 1;
+  public enemyIdCounter = 0;
 
   /**
    * Returns a deep copy of this `State`.
@@ -20,6 +21,7 @@ export default class State {
       state.enemies[id] = this.enemies[id].clone();
     }
     state.wave = this.wave;
+    state.enemyIdCounter = this.enemyIdCounter;
     return state;
   }
 
@@ -37,6 +39,7 @@ export default class State {
     }
 
     flat.push(this.wave);
+    flat.push(this.enemyIdCounter);
   }
 
   public static explode(buf: PopArray): State {
@@ -55,18 +58,20 @@ export default class State {
     }
 
     const wave = buf.pop();
+    const enemyIdCounter = buf.pop();
 
     const state = new State();
     state.players = players;
     state.enemies = enemies;
     state.wave = wave;
+    state.enemyIdCounter = enemyIdCounter;
     return state;
   }
 
   public isSimilarTo(other: State, tolerance: number): boolean {
     // NOTE: this.wave is only used to display a number on the screen. It is not
     // worth it to say that these two states are different solely because of
-    // wave.
+    // wave. Same with this.enemyIdCounter
     const myStuff = [
       ...Object.values(this.players),
       ...Object.values(this.enemies),

--- a/src/common/weapon.ts
+++ b/src/common/weapon.ts
@@ -64,4 +64,11 @@ export default class Weapon {
     w._timeOfLastShot = buf.pop();
     return w;
   }
+
+  public equals(other: Weapon): boolean {
+    return (
+      this._timeOfLastShot === other._timeOfLastShot &&
+      this._weaponType === other._weaponType
+    );
+  }
 }

--- a/src/server/game.ts
+++ b/src/server/game.ts
@@ -44,7 +44,6 @@ export default class ServerGame extends GameLoop {
     );
 
     for (const p of players) {
-      this.simulation.addPlayer(p);
       this.playerInputs[p] = new Deque();
     }
   }

--- a/src/server/game.ts
+++ b/src/server/game.ts
@@ -64,7 +64,6 @@ export default class ServerGame extends GameLoop {
       return j;
     });
     playerInput.merge_back(newInputs); // TODO: check if playerInput and data.inputs are disjunct
-    this.inputAcks[player_id] = playerInput.last;
   }
 
   doUpdate(): void {
@@ -105,8 +104,11 @@ export default class ServerGame extends GameLoop {
   private getNextInput(p: string): TimedInput {
     const playerInput = this.playerInputs[p];
     let input;
+    let inputNum;
     while (playerInput.length > 0) {
-      input = playerInput.pop_front()[0];
+      const tmp = playerInput.pop_front();
+      input = tmp[0];
+      inputNum = tmp[1];
       if (
         playerInput.length === 0 ||
         !this.isOld(input.stateNum) ||
@@ -115,6 +117,8 @@ export default class ServerGame extends GameLoop {
         break;
       }
     }
+
+    if (inputNum !== undefined) this.inputAcks[p] = inputNum;
     return input;
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ function startGame(maxMessageSize?: number): void {
       }
       io.raw.room().emit(x);
     }),
-    Array.from(player_list.map(p => p.player_id)),
+    player_list.map(p => p.player_id),
     random_seed,
   );
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -45,8 +45,8 @@ function startGame(maxMessageSize?: number): void {
   game = new ServerGame(
     new GameMap('scifi-1', 'scifi'),
     drop(
-      SERVER.DROP,
-      delay(SERVER.DELAY, x => {
+      SERVER.NETWORK_DROP_CHANCE,
+      delay(SERVER.NETWORK_DELAY, x => {
         if (maxMessageSize !== undefined && x.byteLength > maxMessageSize) {
           console.warn(
             `Message probably too big! ${x.byteLength} > ${maxMessageSize}`,
@@ -78,8 +78,8 @@ function startGame(maxMessageSize?: number): void {
     );
     p.channel.onRaw(
       drop(
-        SERVER.DROP,
-        delay(SERVER.DELAY, data => game?.clientMsg(p.player_id, data)),
+        SERVER.NETWORK_DROP_CHANCE,
+        delay(SERVER.NETWORK_DELAY, data => game?.clientMsg(p.player_id, data)),
       ),
     );
   }

--- a/src/server/laggyGeckos.ts
+++ b/src/server/laggyGeckos.ts
@@ -1,0 +1,22 @@
+/**
+ * Takes a function `func` and converts it to version that is called `ms`
+ * milliseconds later. The return value of `func` is discarded. If `ms` is 0
+ * then `func` is simply returned, so there will be no function call overhead
+ * if a delay is not desired.
+ * @param ms how long to delay by in milliseconds
+ * @param func the function to delay
+ * @returns a function that will, when executed, call `func` with all passed
+ * parameters after `ms` milliseconds.
+ */
+export function delay(
+  ms: number,
+  func: (...args) => unknown,
+): (...args) => void {
+  if (ms <= 0) {
+    return func;
+  }
+
+  return function(this: unknown, ...args): void {
+    setTimeout(() => func.apply(this, args), ms);
+  };
+}

--- a/src/server/laggyGeckos.ts
+++ b/src/server/laggyGeckos.ts
@@ -20,3 +20,24 @@ export function delay(
     setTimeout(() => func.apply(this, args), ms);
   };
 }
+
+/**
+ * Takes a function `func` and converts it to version that randomly is not run.
+ * @param drop_chance a number between 0 and 1, the chance that `func` is not run.
+ * @param func the function to drop
+ * @returns a function that will, when executed, call `func` with all passed
+ * parameters, sometimes.
+ */
+export function drop<T>(
+  drop_chance: number,
+  func: (...args) => T,
+): (...args) => T | undefined {
+  if (drop_chance === 0) {
+    return func;
+  }
+
+  return function(this: unknown, ...args) {
+    if (Math.random() > drop_chance) return func.apply(this, args);
+    return undefined;
+  };
+}

--- a/src/server/serverSimulation.ts
+++ b/src/server/serverSimulation.ts
@@ -3,8 +3,6 @@ import Simulation from '../common/simulation';
 import GameMap from '../common/gameMap';
 
 export default class ServerSimulation extends Simulation {
-  public difficulty: number;
-
   constructor(
     gameMap: GameMap,
     updateStep: number,
@@ -12,13 +10,10 @@ export default class ServerSimulation extends Simulation {
     seed: string,
   ) {
     super(gameMap, updateStep, numPlayers, seed);
-    this.difficulty = 0;
   }
 
   public update(inputs: Map<Id, Input>): void {
     this.commonUpdate();
-    // update players based on their inputs
-    // TODO: handle 'fire' input
 
     for (const id in this.state.players) {
       const idNum = parseInt(id);
@@ -29,6 +24,6 @@ export default class ServerSimulation extends Simulation {
 
     this.world.step(this.updateStep);
 
-    super.updateState();
+    this.updateState();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
         /* Basic Options */
         // "incremental": true,                   /* Enable incremental compilation */
-        "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+        "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
         "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
         // "lib": [],                             /* Specify library files to be included in the compilation. */
         // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Client side prediction (CSP) can now be enabled via a flag in constants! Closes #124 

It only predicts your own movement. It does not predict where things spawn nor what other players are doing, it was difficult to do. It does not work super well and CPU usage is higher (I think), but now we can say that we have it at least :sweat_smile:. It does work, but not well enough to use it by default.

To support this I had to change/add:
- This fixes the same cloning issues as #153, and more! I suggest we close that one.
- An equality check between states, don't need to re-predict if we predicted correctly.
- changes in all simulation classes to support prediction (mostly in ClientSimulation.ts).
- Updated Typescript compilation target as it was necessary to be able to use the iterator in Deque.
- move `Simulation._enemyIdCounter` to `State` as `ClientSimulation` needs it in its reset function.
- inputAck in ServerToClient now means" last processed input" instead of "last received input". Each network package is slighty larger (3-5 bytes depending on ping), but it was much easier and more elegant than the alternatives.
- Seedrandom is no longer required. We probably do want randomness in the future so I didn't remove it completely, only ignore it where it was used.

Non-needed changes and cleanup that maybe shouldn't belong here (sry)
- Removed unused difficulty variable in ServerSimulation.
- Deque has a new shift_forward method that isn't used at the moment. It might be useful in the future though.
- Simulated constant network delay and drop chance to be able to test how well CSP is working.

I think that was everything!

New issues that should be created:
- Lasers from other players aren't showing when CSP is on.

P.S. Jag vet inte varför jag skrev på engelska :sweat_smile: 